### PR TITLE
[Landcover Toolkit] Script to push source to arbitrary EE repo

### DIFF
--- a/toolkits/landcover/api.js
+++ b/toolkits/landcover/api.js
@@ -17,9 +17,9 @@
  * @fileoverview Main entry point for toolkit.
  */
 
-var Landsat8 = require('users/gmiceli/ee-lct:impl/landsat8.js').Landsat8;
-var Region = require('users/gmiceli/ee-lct:impl/region.js').Region;
-var Composites = require('users/gmiceli/ee-lct:impl/composites.js').Composites;
+var Landsat8 = require('users/google/toolkits:landcover/impl/landsat8.js').Landsat8;
+var Region = require('users/google/toolkits:landcover/impl/region.js').Region;
+var Composites = require('users/google/toolkits:landcover/impl/composites.js').Composites;
 
 exports.Landsat8 = Landsat8;
 exports.Region = Region;

--- a/toolkits/landcover/ee_repo_sync.py
+++ b/toolkits/landcover/ee_repo_sync.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Pushes required toolkit source to an Earth Engine repo."""
+
+import argparse
+import subprocess
+import os
+
+WORK_PATH = '~/.ee_repo_sync'
+GIT_BASE_URL = 'https://earthengine.googlesource.com'
+ORIGINAL_REQUIRE_PATH = 'users/google/toolkits:landcover/'
+SOURCE_PATHS = ['api.js', 'impl', 'examples']
+
+# Declare args and help text
+parser = argparse.ArgumentParser(
+    description='''
+    Pushes required toolkit source to an Earth Engine repo, updating require()
+    paths as necessary, overwriting remote changes.
+    Example usage:
+    ./ee_repo_sync.py
+      --target_repo=users/%s/toolkits
+      --target_path=landcover
+    ''' % os.getlogin())
+parser.add_argument('--target_repo', required=True,
+                    help='Destination Earth Engine repo path (required)')
+parser.add_argument('--target_path',
+                    help='Destination path in target repo (default: root)')
+args = parser.parse_args()
+
+repo = args.target_repo
+target_path = args.target_path
+repo_url = GIT_BASE_URL + '/' + repo
+clone_path = os.path.expanduser(os.path.join(WORK_PATH, repo))
+write_path = os.path.join(clone_path, target_path)
+new_require_path = repo + ":"
+if (target_path):
+    new_require_path += target_path + "/"
+
+# Clone or pull repo to home dir
+if not os.path.isdir(clone_path):
+    subprocess.call(["git", "clone", repo_url, clone_path])
+else:
+    subprocess.call(["git", "-C", clone_path, "pull"])
+
+subprocess.call(["mkdir", "-p", write_path])
+
+# Copy selected files to local clone
+for source in SOURCE_PATHS:
+    subprocess.call(['rsync', '--archive', '--delete-excluded',
+                     "--include='*.js'",
+                     "--exclude='*'",
+                     source,
+                     write_path])
+
+# Search and replace paths
+os.system("find %s -name '*.js' -exec sed -i '' 's|%s|%s|g' {} \;" %
+          (write_path, ORIGINAL_REQUIRE_PATH, new_require_path))
+
+# Commit and push changes
+subprocess.call(["git", "-C", clone_path, "add", clone_path])
+subprocess.call(["git", "-C", clone_path, "commit", "-m",
+                 "Automated commit by ee_repo_sync.py"])
+subprocess.call(["git", "-C", clone_path, "push"])

--- a/toolkits/landcover/examples/filter-and-fmask.js
+++ b/toolkits/landcover/examples/filter-and-fmask.js
@@ -20,7 +20,7 @@
  */
 
 // TODO(gino-m): Replace with shared code repo.
-var lct = require('users/gmiceli/ee-lct:api.js');
+var lct = require('users/google/toolkits:landcover/api.js');
 
 // Create a new dataset, filter by date, country, and mask clouds and shadows.
 var dataset = lct.Landsat8()

--- a/toolkits/landcover/impl/dataset.js
+++ b/toolkits/landcover/impl/dataset.js
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-var Composites = require('users/gmiceli/ee-lct:impl/composites.js').Composites;
-var Bands = require('users/gmiceli/ee-lct:impl/bands.js').Bands;
+var Composites = require('users/google/toolkits:landcover/impl/composites.js').Composites;
+var Bands = require('users/google/toolkits:landcover/impl/bands.js').Bands;
 
 /**
  * Returns a new dataset instance for an arbitrary image collection.

--- a/toolkits/landcover/impl/landsat8.js
+++ b/toolkits/landcover/impl/landsat8.js
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-var Dataset = require('users/gmiceli/ee-lct:impl/dataset.js').Dataset;
+var Dataset = require('users/google/toolkits:landcover/impl/dataset.js').Dataset;
 
 var COMMON_BAND_NAMES = {
   'B1': 'coastal',

--- a/toolkits/landcover/test/helpers/globals.js
+++ b/toolkits/landcover/test/helpers/globals.js
@@ -22,6 +22,10 @@
 var ee = require('@google/earthengine');
 var Module = require('module');
 
+// Base path of shared repo containing toolkit source. Replaced with relative
+// paths when running tests.
+var SHARED_REPO_PREFIX_REGEX = /^.*:landcover\//;
+
 // Make ee namespace available to all modules.
 global.ee = ee;
 
@@ -37,7 +41,7 @@ var _require = Module.prototype.require;
  * @return {!Module} The required module.
  */
 Module.prototype.require = function(path) {
-  path = path.replace(/^.*:/, __dirname + '/../../');
+  path = path.replace(SHARED_REPO_PREFIX_REGEX, __dirname + '/../../');
   path = Module._resolveFilename(path, this);
   return _require.call(this, path);
 };


### PR DESCRIPTION
A quick hack to allow us to interactively test and iterate more quickly.

Example usage:
```bash
$ ./ee_repo_sync.py --target_repo=users/$USER/toolkits --target_path=landcover
```

The script does the following:
- [x] Clones the remote EE repo to a temp dir in user working path
- [x] Pulls any remote changes to the temp dir
- [x] Copies API, impl, and example js files over local clone
- [x] Replaces hard-coded repo paths so they can work in the Code Editor
- [x] Commits and pushes to the repo

This PR also renamed hard-coded repo paths in code to point to a generic temporary location (`users/google/toolkit`, repo TBD).

The script doesn't support two-way sync, so changes made in Code Editor will be overwritten.

![image](https://user-images.githubusercontent.com/228050/63899287-50578300-c9ca-11e9-94c5-d43461df647f.png)
