### PR TITLE
[Landcover Toolkit] Generic cloud mask interface

### DIFF
--- a/toolkits/landcover/examples/filter-and-fmask.js
+++ b/toolkits/landcover/examples/filter-and-fmask.js
@@ -26,7 +26,7 @@ var lct = require('users/google/toolkits:landcover/api.js');
 var dataset = lct.Landsat8()
                   .filterDate('2018-06-01', '2019-01-01')
                   .filterBounds(lct.Region.lsib('Tanzania'))
-                  .fmaskCloudsAndShadows();
+                  .maskCloudsAndShadows();
 
 // Add the resulting ImageCollection to the map, taking the median of
 // overlapping pixel values.

--- a/toolkits/landcover/impl/dataset.js
+++ b/toolkits/landcover/impl/dataset.js
@@ -15,7 +15,8 @@
  * limitations under the License.
  */
 
-var Composites = require('users/google/toolkits:landcover/impl/composites.js').Composites;
+var Composites =
+    require('users/google/toolkits:landcover/impl/composites.js').Composites;
 var Bands = require('users/google/toolkits:landcover/impl/bands.js').Bands;
 
 /**
@@ -104,11 +105,10 @@ Dataset.prototype.getDefaultVisParams = function() {
  *        each time period. Defaults to using a median reducer.
  * @return {!ee.ImageCollection}
  */
-Dataset.prototype.createTemporalComposites =
-    function(startDate, count, interval, intervalUnits, reducer) {
-  this.collection_ =
-      Composites.createTemporalComposites(
-          this.collection_, startDate, count, interval, intervalUnits, reducer);
+Dataset.prototype.createTemporalComposites = function(
+    startDate, count, interval, intervalUnits, reducer) {
+  this.collection_ = Composites.createTemporalComposites(
+      this.collection_, startDate, count, interval, intervalUnits, reducer);
   return this;
 };
 
@@ -122,9 +122,8 @@ Dataset.prototype.createTemporalComposites =
  * @return {!ee.ImageCollection}
  */
 Dataset.prototype.createMedioidComposite = function(band) {
-  this.collection_ = ee.ImageCollection([
-      Composites.createMedioidComposite(this.collection_, band)
-  ]);
+  this.collection_ = ee.ImageCollection(
+      [Composites.createMedioidComposite(this.collection_, band)]);
   return this;
 };
 
@@ -204,5 +203,18 @@ Dataset.prototype.addFractionalYearBand = function() {
   return this;
 };
 
+/**
+ * Generic interface for applying clouds and shadow shadow masks to a
+ * collection. Subclasses that support this operation should override this
+ * method to provide a default implementation (e.g., CFMASK). Subclasses may
+ * also specify additional arguments to control which methodology is used and
+ * related parameters.
+ *
+ * Subclasses must return a new instance of the dataset with the masks
+ * applied.
+ */
+Dataset.prototype.maskCloudsAndShadows = function() {
+  throw new Error('Unimplemented method');
+};
 
 exports.Dataset = Dataset;

--- a/toolkits/landcover/impl/dataset.js
+++ b/toolkits/landcover/impl/dataset.js
@@ -204,7 +204,7 @@ Dataset.prototype.addFractionalYearBand = function() {
 };
 
 /**
- * Generic interface for applying clouds and shadow shadow masks to a
+ * Generic interface for applying cloud and shadow shadow masks to a
  * collection. Subclasses that support this operation should override this
  * method to provide a default implementation (e.g., CFMASK). Subclasses may
  * also specify additional arguments to control which methodology is used and

--- a/toolkits/landcover/impl/landsat8.js
+++ b/toolkits/landcover/impl/landsat8.js
@@ -15,7 +15,8 @@
  * limitations under the License.
  */
 
-var Dataset = require('users/google/toolkits:landcover/impl/dataset.js').Dataset;
+var Dataset =
+    require('users/google/toolkits:landcover/impl/dataset.js').Dataset;
 
 var COMMON_BAND_NAMES = {
   'B1': 'coastal',
@@ -60,18 +61,16 @@ Landsat8.prototype = Object.create(Dataset.prototype);
 Landsat8.prototype.COMMON_BAND_NAMES = COMMON_BAND_NAMES;
 
 /**
- * Masks clouds and shadows using relevant bits in the `pixel_qa` band generated
- * by the CFMASK algorithm.
+ * Masks clouds and shadows using relevant bits in the `pixel_qa` band. In
+ * Landsat 8 datasets, the pixel QA bits are generated using the CFMASK
+ * algorithm.
  *
- * Returns the modified dataset.
+ * Returns the dataset with the masks applied.
  *
  * @return {!Landsat8}
  */
-Landsat8.prototype.fmaskCloudsAndShadows = function() {
-  // TODO(gorelick): Is BQA in TOA calculated using Fmask as well? If so, how do
-  // we model and/or abstract this for the user?
-  // TODO(gino-m): Do something different or fail for type != 'SR'.
-  this.collection_ = this.collection_.map(Landsat8.applyCloudShadowBitMasks);
+Landsat8.prototype.maskCloudsAndShadows = function() {
+  this.collection_ = this.collection_.map(Landsat8.maskCloudsAndShadows);
   return this;
 };
 
@@ -84,7 +83,7 @@ Landsat8.prototype.fmaskCloudsAndShadows = function() {
  * @param {!ee.Image} image The image to be masked.
  * @return {!ee.Image}
  */
-Landsat8.applyCloudShadowBitMasks = function(image) {
+Landsat8.maskCloudsAndShadows = function(image) {
   var qa = image.select(QA_BAND);
   // Both flags should be set to zero, indicating clear conditions.
   var mask = qa.bitwiseAnd(CLOUD_SHADOW_BIT_MASK)

--- a/toolkits/landcover/impl/landsat8.js
+++ b/toolkits/landcover/impl/landsat8.js
@@ -67,6 +67,7 @@ Landsat8.prototype.COMMON_BAND_NAMES = COMMON_BAND_NAMES;
  *
  * Returns the dataset with the masks applied.
  *
+ * @override
  * @return {!Landsat8}
  */
 Landsat8.prototype.maskCloudsAndShadows = function() {

--- a/toolkits/landcover/test/int/landsat8.int.test.js
+++ b/toolkits/landcover/test/int/landsat8.int.test.js
@@ -24,7 +24,7 @@ withEarthEngine('Landsat8', function() {
     var image = lct.Landsat8('SR')
                     .filterDate('2018-01-01', '2018-04-01')
                     .filterBounds(point)
-                    .fmaskCloudsAndShadows()
+                    .maskCloudsAndShadows()
                     .getImageCollection()
                     .mosaic();
 

--- a/toolkits/landcover/test/unit/landsat8.unit.test.js
+++ b/toolkits/landcover/test/unit/landsat8.unit.test.js
@@ -21,7 +21,7 @@ withEarthEngineStub('Landsat8', function() {
   it('applyCloudAndShadowBitMasks() updates mask', function() {
     var originalImage = ee.Image(0);
 
-    var newImage = Landsat8.applyCloudShadowBitMasks(originalImage);
+    var newImage = Landsat8.maskCloudsAndShadows(originalImage);
 
     var qa = originalImage.select(Landsat8.QA_BAND);
     var mask = qa.bitwiseAnd(Landsat8.CLOUD_SHADOW_BIT_MASK)


### PR DESCRIPTION
- [x] Renames cloud mask function to more generic name. CFMask is treated as an implementation detail. If we have multiple methods, we can provide the method as an argument, or create separate more specific methods to disambiguate.
- [x] Adds a generic method to the Dataset base class. Throws an error if unimplemented.