### PR TITLE
[Landcover toolkit] Deterministic integration tests

### DIFF
--- a/toolkits/landcover/impl/composites.js
+++ b/toolkits/landcover/impl/composites.js
@@ -94,7 +94,9 @@ function createMedioidComposite(collection, indexBand) {
   // Compute the median of the index band.
   indexBand = indexBand === undefined ? 0 : indexBand;
   var median = collection.select(indexBand).median();
-
+  
+  // Add a band containing the difference between the index band value for each
+  // pixel and the median of the index band across all pixels in the collection.
   var mosaic = collection.map(function(img) {
     var diff = median.subtract(img.select(indexBand)).abs();
     var index = ee.Image(0).subtract(diff);

--- a/toolkits/landcover/impl/dataset.js
+++ b/toolkits/landcover/impl/dataset.js
@@ -22,15 +22,14 @@ var Bands = require('users/google/toolkits:landcover/impl/bands.js').Bands;
  * Returns a new dataset instance for an arbitrary image collection.
  *
  * @constructor
- * @param {string} id The id of the collection in the Earth Engine data
- *     catalog.
+ * @param {!ee.ImageCollection} collection The collection backing this dataset.
  * @param {!ee.data.ImageVisualizationParameters} defaultVisParams The
  *     parameters to be used when adding the resulting collection to a layer for
  *     visualization.
  * @return {!Dataset}
  */
-var Dataset = function(id, defaultVisParams) {
-  this.collection_ = ee.ImageCollection(id);
+var Dataset = function(collection, defaultVisParams) {
+  this.collection_ = collection;
   this.defaultVisParams_ = defaultVisParams;
 };
 

--- a/toolkits/landcover/impl/landsat8.js
+++ b/toolkits/landcover/impl/landsat8.js
@@ -50,7 +50,8 @@ var Landsat8 = function() {
   }
 
   // TODO(gino-m): Accept `type` "SR"|"TOA".
-  Dataset.call(this, 'LANDSAT/LC08/C01/T1_SR', DEFAULT_VIS_PARAMS);
+  Dataset.call(
+      this, ee.ImageCollection('LANDSAT/LC08/C01/T1_SR'), DEFAULT_VIS_PARAMS);
 };
 
 // Extend Dataset class. This causes Landsat8 to inherit all method and

--- a/toolkits/landcover/test/helpers/test-image.js
+++ b/toolkits/landcover/test/helpers/test-image.js
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Maximum number of constant images to fetch when processing test data
+// collections.
+var MAX_TEST_COLLECTION_SIZE = 15;
+/**
+ * Returns a single constant ee.Image comprised of the bands and values in the
+ * specified dictionary.
+ *
+ * @param {*} values A dictionary containing band names as keys and
+ *    corresponding numeric values. The values are used to build an ee.Image
+ *    with a single constant value in each respective band.
+ * @param {string} startDate An optional start date for the image, in YYYY-MM-DD
+ *    format.
+ * @returns {!ee.Image}
+ */
+var create = function(values, startDate) {
+  var image = ee.Dictionary(values).toImage().int64();
+
+  if (startDate) {
+    image = image.set('system:time_start', ee.Date(startDate).millis());
+  }
+  return image;
+};
+
+/**
+ * Reduces the specified constant ee.Image to a dictionary with one key per
+ * band.
+ *
+ * @param {!ee.Image} image A constant ee.Image (an image with a single value).
+ * @returns {*} A dictionary keyed by band name.
+ */
+var reduceConstant = function(image) {
+  // DO NOT MERGE - USE .sample() INSTEAD?
+  return ee.Image(image)
+           .reduceRegion(ee.Reducer.first(), ee.Geometry.Point(0, 0), 1);
+  };
+  
+/**
+ * Reduces a collection of constant ee.Image instances to a list of    
+ * dictionaries keyed by band.
+ *
+ * @param {!ee.ImageCollection} collection A collection containing only constant
+ *     ee.Image instances (images with a single value).
+ * @returns {Array} An array of dictionaries keyed by band name.
+ */
+var reduceConstants = function(collection) {
+  return collection.toList(MAX_TEST_COLLECTION_SIZE).map(reduceConstant);
+};
+
+exports.create = create;
+exports.reduceConstant = reduceConstant;
+exports.reduceConstants = reduceConstants;

--- a/toolkits/landcover/test/helpers/test-image.js
+++ b/toolkits/landcover/test/helpers/test-image.js
@@ -18,6 +18,7 @@
 // Maximum number of constant images to fetch when processing test data
 // collections.
 var MAX_TEST_COLLECTION_SIZE = 15;
+
 /**
  * Returns a single constant ee.Image comprised of the bands and values in the
  * specified dictionary.

--- a/toolkits/landcover/test/helpers/test-image.js
+++ b/toolkits/landcover/test/helpers/test-image.js
@@ -46,7 +46,6 @@ var create = function(values, startDate) {
  * @returns {*} A dictionary keyed by band name.
  */
 var reduceConstant = function(image) {
-  // DO NOT MERGE - USE .sample() INSTEAD?
   return ee.Image(image)
            .reduceRegion(ee.Reducer.first(), ee.Geometry.Point(0, 0), 1);
   };

--- a/toolkits/landcover/test/int/composites.int.test.js
+++ b/toolkits/landcover/test/int/composites.int.test.js
@@ -1,0 +1,119 @@
+/**
+ * @license
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var lct = require('../../api.js');
+var TestImage = require('../helpers/test-image.js');
+
+withEarthEngine('Composites', function() {
+  it('createTemporalComposites()', function(done) {
+    var testCollection = ee.ImageCollection([
+      TestImage.create({value: 100}, '2015-12-01'),
+      TestImage.create({value: 150}, '2015-12-15'),
+      TestImage.create({value: 200}, '2016-01-01'),
+      TestImage.create({value: 250}, '2016-01-15'),
+      TestImage.create({value: 300}, '2016-02-01'),
+      TestImage.create({value: 350}, '2016-02-15'),
+      TestImage.create({value: 400}, '2016-03-01'),
+      TestImage.create({value: 450}, '2016-03-15'),
+      TestImage.create({value: 500}, '2016-04-01'),
+      TestImage.create({value: 550}, '2016-04-15')
+    ]);
+
+    // TODO(#38): Replace args with dictionary once names args is implemented.
+    var result = lct.Composites.createTemporalComposites(
+        testCollection,
+        /* startDate= */ '2016-01-01',
+        /* count= */ 3,
+        /* interval= */ 1,
+        /* intervalUnits= */ 'month', ee.Reducer.mean());
+
+    TestImage.reduceConstants(result.select('value'))
+        .evaluate(function(actual, error) {
+          expect(error).toBeUndefined();
+          // Mean value in each valid 3 month range.
+          expect(actual).toEqual([{value: 225}, {value: 325}, {value: 425}]);
+          done();
+        });
+  });
+
+  it('createMedioidComposite()', function(done) {
+    // Median idx = 3, so we expect the pixel(s) with idx closest to that
+    // value to be returned.
+    var testCollection = ee.ImageCollection([
+      // Value #1 for medioid function:
+      TestImage.create({idx: 1, value: 10}),
+      // Value #2 for medioid function:
+      TestImage.create({idx: 2, value: 30}),
+      // Value #3 for medioid function (medioid):
+      TestImage.create({idx: 3, value: 300}),
+      // Value #4 for medioid function:
+      TestImage.create({idx: 4, value: 400})
+    ]);
+
+    var composite =
+        lct.Composites.createMedioidComposite(testCollection, 'idx');
+
+    TestImage.reduceConstant(composite).evaluate(function(actual, error) {
+      expect(error).toBeUndefined();
+      expect(actual).toEqual({idx: 3, value: 300});
+      done();
+    });
+  });
+
+  it('createMedioidFunction()', function(done) {
+    // The first and last dates will be excluded by the temporal composite
+    // criteria below. The 5 images in between will be used, with mosaic
+    // built using median index value of 3.
+    var testCollection = ee.ImageCollection([
+      // This date will be filtered out.
+      TestImage.create({idx: 0, value: 0}, '2015-12-01'),
+      // Value #1 for medioid function:
+      TestImage.create({idx: 1, value: 10}, '2016-01-01'),
+      // Value #2 for medioid function:
+      TestImage.create({idx: 2, value: 20}, '2016-01-02'),
+      // Value #3 for medioid function (medioid):
+      TestImage.create({idx: 3, value: 400}, '2016-01-03'),
+      // Value #4 for medioid function;
+      TestImage.create({idx: 4, value: 500}, '2016-01-04'),
+      // This will also be filtered out (>31d after 2016-01-01).
+      TestImage.create({idx: 5, value: 600}, '2016-06-01')
+    ]);
+
+    // With 1 composite, this should be equivalent to the
+    // medioidComposite test.
+    var compositor = lct.Composites.createMedioidFunction('idx');
+    // TODO(#38): Replace args with dictionary once names args is implemented.
+    var result = lct.Composites.createTemporalComposites(
+        testCollection,
+        /* startDate= */ '2016-01-01',
+        /* count= */ 1,
+        /* interval= */ 31,
+        /* intervalUnits= */ 'day', compositor);
+
+    TestImage.reduceConstants(result).evaluate(function(actual, error) {
+      expect(error).toBeUndefined();
+      // Mean value in each valid 3 month range.
+      expect(actual).toEqual([{
+        date: new Date('2016-01-03').getTime(),
+        idx: 3,
+        observations: 4,
+        value: 400
+      }]);
+      done();
+    });
+  });
+});

--- a/toolkits/landcover/test/int/dataset.int.test.js
+++ b/toolkits/landcover/test/int/dataset.int.test.js
@@ -15,23 +15,56 @@
  * limitations under the License.
  */
 
-var assert = require('assert');
-var lct = require('../../api.js');
+var Dataset = require('../../impl/dataset.js').Dataset;
+var TestImage = require('../helpers/test-image.js');
 
-var geometry;
-var dataset;
+// Values used to construct test dataset.
+var TEST_VALUES = {
+  B1: 1000,
+  B2: 2000,
+  B3: 3000,
+  B4: 4000,
+  B5: 5000,
+  B6: 6000,
+  B7: 7000,
+  B8: 8000,
+  B9: 9000,
+  B10: 10000,
+  B11: 11000
+};
+
+// Subset of indices calculated using on TEST_VALUES.
+var TEST_INDICES = {
+  ndvi: (5000 - 4000) / (5000 + 4000),
+  ndsi: (3000 - 6000) / (3000 + 6000),
+};
+
+var TEST_COMMON_BAND_NAMES = {
+  'B1': 'coastal',
+  'B2': 'blue',
+  'B3': 'green',
+  'B4': 'red',
+  'B5': 'nir',
+  'B6': 'swir1',
+  'B7': 'swir2',
+  'B8': 'pan',
+  'B9': 'cirrus',
+  'B10': 'thermal1',
+  'B11': 'thermal2'
+};
+
+var TestDataset = function(values) {
+  var testImage = TestImage.create(values);
+  var testCollection = ee.ImageCollection([testImage]);
+  dataset = new Dataset(testCollection);
+  dataset.COMMON_BAND_NAMES = TEST_COMMON_BAND_NAMES;
+  return dataset;
+};
 
 withEarthEngine('Dataset', function() {
-  beforeEach(function() {
-    // A point in Arizona.
-    geometry = ee.Geometry.Point([-111.70715, 36.0225]);
-    dataset = lct.Landsat8('SR')
-        .filterDate('2016-01-02', '2016-01-03')
-        .filterBounds(geometry);
-  });
-
-  it('Generate common band names', function(done) {
-    dataset.computeCommonBandNames_(ee.List(['B4', 'B3', 'B2', 'foo']))
+  it('computeCommonBandNames_()', function(done) {
+    TestDataset(TEST_VALUES)
+        .computeCommonBandNames_(ee.List(['B4', 'B3', 'B2', 'foo']))
         .evaluate(function(actual, error) {
           expect(error).toBeUndefined();
           expect(actual).toEqual(['red', 'green', 'blue', 'foo']);
@@ -39,67 +72,15 @@ withEarthEngine('Dataset', function() {
         });
   });
 
-  it('Add spectral indices', function(done) {
-    dataset.addBandIndices('ndvi', 'ndsi')
-        .getImageCollection()
-        .first()
-        .bandNames().evaluate(function(actual, error) {
-          expect(error).toBeUndefined();
-          expect(actual).toContain('ndvi');
-          expect(actual).toContain('ndsi');
-          // Make sure our original bands are still there too.
-          expect(actual).toContain('B3');
-          done();
-        });
-  });
-
-  it('Make temporalComposites', function(done) {
-    lct.Landsat8('SR')
-        .filterBounds(geometry)
-        .createTemporalComposites('2016-01-01', 12, 7, 'day')
-        .getImageCollection()
+  it('addBandIndices()', function(done) {
+    var l8 = TestDataset(TEST_VALUES).addBandIndices('ndvi', 'ndsi');
+    TestImage.reduceConstant(l8.getImageCollection().first())
         .evaluate(function(actual, error) {
           expect(error).toBeUndefined();
-          // About 1/2 of the dates have no images.
-          expect(actual.features.length).toBe(5);
-          expect(actual.features[0]['id']).toBe('20160101');
-          done();
-        });
-  });
-
-  it('Compute medioidComposite', function(done) {
-    lct.Landsat8('SR')
-        .filterBounds(geometry)
-        .filterDate('2016-01-01', '2016-01-31')
-        .addDayOfYearBand()
-        .createMedioidComposite('doy')
-        .getImageCollection()
-        .first()
-        .reduceRegion(ee.Reducer.first(), geometry, 1)
-        .evaluate(function(actual, error) {
-          expect(error).toBeUndefined();
-          expect(actual['doy']).toBe(17);
-          done();
-        });
-  });
-
-  it('MedioidFunction in temporalComposites', function(done) {
-    // With 1 composite,this should be equivalent to the
-    // medioidComposite test.
-    var compositor = lct.Composites.createMedioidFunction('date');
-    lct.Landsat8('SR')
-        .filterBounds(geometry)
-        .addDayOfYearBand()
-        .addFractionalYearBand()
-        .createTemporalComposites('2016-01-01', 1, 31, 'day', compositor)
-        .getImageCollection()
-        .first()
-        .reduceRegion(ee.Reducer.first(), geometry, 1)
-        .evaluate(function(actual, error) {
-          expect(error).toBeUndefined();
-          expect(actual['date']).toBe(1453140198110);
-          expect(actual['doy']).toBe(17);
-          expect(actual['fYear']).toBeCloseTo(2016 + 17/365.0, 0.001);
+          // Check calculated values to ensure index expressions are correct and
+          // that original bands are still present.
+          var expected = Object.assign({}, TEST_VALUES, TEST_INDICES);
+          expect(actual).toEqual(expected);
           done();
         });
   });


### PR DESCRIPTION
Updates integrations tests to take fake data. This removes dependence on actual Earth Engine datasets, making expected post-conditions entirely dependent on values defined in the tests rather than "golden" values that we expect based on actual imagery.

Resubmitting removing formatting changes and addressing comments in #16. PTAL.

