### PR TITLE
[Landcover Toolkit] Repo-wide .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
-**/.*
+.*
+coverage
 node_modules
+out
 !.gitignore
 !.eslintrc.yml

--- a/toolkits/landcover/.gitignore
+++ b/toolkits/landcover/.gitignore
@@ -1,6 +1,0 @@
-!.gitignore
-!.eslintrc.json
-**/.*
-coverage
-node_modules
-out


### PR DESCRIPTION
Avoids issue with IntelliJ and other unwanted files getting picked up by git.