### PR TITLE
[Landcover Toolkit] Add support for named args

### DIFF
--- a/toolkits/landcover/impl/bands.js
+++ b/toolkits/landcover/impl/bands.js
@@ -76,7 +76,7 @@ var SPECTRAL_INDEX_EXPRESSIONS = {
 function getSpectralIndices(image, indices) {
   var args = NamedArgs.extractFromFunction(getSpectralIndices, arguments);
   image = args.image;
-  indicies = args.indices;
+  indices = args.indices;
   // We can't check the existence of the specified indices if they're EEObjects.
   if (!(indices instanceof ee.ComputedObject)) {
     // Check that all the specified indexes exist.

--- a/toolkits/landcover/impl/bands.js
+++ b/toolkits/landcover/impl/bands.js
@@ -17,6 +17,8 @@
  * @fileoverview Static functions for band transformations.
  */
 
+ var NamedArgs = require('users/google/toolkits:landcover/impl/named-args').NamedArgs;
+
 var SPECTRAL_INDEX_EXPRESSIONS = {
   // Note, this is a literal dictionary so we can check for the existence
   // of a given spectral index before sending the query.
@@ -72,6 +74,9 @@ var SPECTRAL_INDEX_EXPRESSIONS = {
  * @return {ee.Image} The updated image.
  */
 function getSpectralIndices(image, indices) {
+  var args = NamedArgs.extractFromFunction(getSpectralIndices, arguments);
+  image = args.image;
+  indicies = args.indices;
   // We can't check the existence of the specified indices if they're EEObjects.
   if (!(indices instanceof ee.ComputedObject)) {
     // Check that all the specified indexes exist.
@@ -97,6 +102,8 @@ function getSpectralIndices(image, indices) {
  * @return {!ee.ImageCollection}
  */
 function addDateBand(collection) {
+  var args = NamedArgs.extractFromFunction(addDateBand, arguments);
+  collection = args.collection;
   return collection.map(function(img) {
     var date = ee.Image.constant(img.date().millis())
         .rename('date').long();
@@ -112,6 +119,8 @@ function addDateBand(collection) {
  * @return {!ee.ImageCollection}
  */
 function addDayOfYearBand(collection) {
+  var args = NamedArgs.extractFromFunction(addDayOfYearBand, arguments);
+  collection = args.collection;
   return collection.map(function(img) {
     var doy = ee.Image.constant(img.date().getRelative('day', 'year'))
         .rename('doy').int();
@@ -127,6 +136,8 @@ function addDayOfYearBand(collection) {
  * @return {!ee.ImageCollection}
  */
 function addFractionalYearBand(collection) {
+  var args = NamedArgs.extractFromFunction(addFractionalYearBand, arguments);
+  collection = args.collection;
   return collection.map(function(img) {
     var date = img.date();
     var fYear = date.get('year').double().add(img.date().getFraction('year'));

--- a/toolkits/landcover/impl/composites.js
+++ b/toolkits/landcover/impl/composites.js
@@ -17,6 +17,8 @@
  * @fileoverview Static functions for compositing.
  */
 
+var NamedArgs = require('users/google/toolkits:landcover/impl/named-args').NamedArgs;
+
 /**
  * Convert a collection into composite images based on fixed time intervals.
  * Adds a 'date' band to each input image that contains the date of the
@@ -37,10 +39,13 @@
  */
 function createTemporalComposites(
     collection, startDate, count, interval, intervalUnits, compositor) {
-  compositor = compositor || ee.Reducer.median();
-  count = ee.Number(count);
-  interval = ee.Number(interval);
-  startDate = ee.Date(startDate);
+  var args = NamedArgs.extractFromFunction(createTemporalComposites, arguments);
+  collection = args.collection;
+  startDate = ee.Date(args.startDate);
+  count = ee.Number(args.count);
+  interval = ee.Number(args.interval);
+  intervalUnits = args.intervalUnits;
+  compositor = args.compositor || ee.Reducer.median();
   var images = ee.List.sequence(0, count.subtract(1)).map(function(n) {
     // Compute temporal extent for one interval.
     var begin = startDate.advance(interval.multiply(n), intervalUnits);
@@ -92,7 +97,9 @@ function createTemporalComposites(
  * @return {!ee.ImageCollection}
  */
 function createMedioidComposite(collection, bands) {
-  bands = bands === undefined ? '.*' : bands;
+  var args = NamedArgs.extractFromFunction(createMedioidComposite, arguments);
+  var collection = args.collection;
+  var bands = args.bands === undefined ? '.*' : args.bands;
 
   // Compute the distance from the median of the index band.
   var median = collection.select(bands).median();
@@ -118,8 +125,9 @@ function createMedioidComposite(collection, bands) {
  * @return {function(*=): !ee.ImageCollection}
  */
 function createMedioidFunction(bands) {
+  var args = NamedArgs.extractFromFunction(createMedioidFunction, arguments);
   return function(collection) {
-    return createMedioidComposite(collection, bands);
+    return createMedioidComposite(collection, args.bands);
   };
 }
 

--- a/toolkits/landcover/impl/composites.js
+++ b/toolkits/landcover/impl/composites.js
@@ -98,8 +98,8 @@ function createTemporalComposites(
  */
 function createMedioidComposite(collection, bands) {
   var args = NamedArgs.extractFromFunction(createMedioidComposite, arguments);
-  var collection = args.collection;
-  var bands = args.bands === undefined ? '.*' : args.bands;
+  collection = args.collection;
+  bands = args.bands === undefined ? '.*' : args.bands;
 
   // Compute the distance from the median of the index band.
   var median = collection.select(bands).median();
@@ -126,8 +126,9 @@ function createMedioidComposite(collection, bands) {
  */
 function createMedioidFunction(bands) {
   var args = NamedArgs.extractFromFunction(createMedioidFunction, arguments);
+  var bands = args.bands;
   return function(collection) {
-    return createMedioidComposite(collection, args.bands);
+    return createMedioidComposite(collection, bands);
   };
 }
 

--- a/toolkits/landcover/impl/dataset.js
+++ b/toolkits/landcover/impl/dataset.js
@@ -17,6 +17,7 @@
 
 var Composites = require('users/google/toolkits:landcover/impl/composites.js').Composites;
 var Bands = require('users/google/toolkits:landcover/impl/bands.js').Bands;
+var NamedArgs = require('users/google/toolkits:landcover/impl/named-args').NamedArgs;
 
 /**
  * Returns a new dataset instance for an arbitrary image collection.
@@ -104,8 +105,11 @@ Dataset.prototype.getDefaultVisParams = function() {
  */
 Dataset.prototype.createTemporalComposites = function(
     startDate, count, interval, intervalUnits, reducer) {
+  var args = NamedArgs.extractFromFunction(
+      Dataset.prototype.createTemporalComposites, arguments);
   this.collection_ = Composites.createTemporalComposites(
-      this.collection_, startDate, count, interval, intervalUnits, reducer);
+      this.collection_, args.startDate, args.count, args.interval,
+      args.intervalUnits, args.reducer);
   return this;
 };
 

--- a/toolkits/landcover/impl/dataset.js
+++ b/toolkits/landcover/impl/dataset.js
@@ -45,6 +45,9 @@ var Dataset = function(collection, defaultVisParams) {
  * @return {!Dataset}
  */
 Dataset.prototype.filterDate = function(start, end) {
+  var args = NamedArgs.extractFromFunction(Dataset.prototype.filterDate, arguments);
+  start = args.start;
+  end = args.end;
   // TODO(gino-m): Implement month and year ranges.
   // TODO(gino-m): Implement single day/month/year.
   this.collection_ = this.collection_.filterDate(start, end);
@@ -64,6 +67,8 @@ Dataset.prototype.filterDate = function(start, end) {
  * @return {!Dataset}
  */
 Dataset.prototype.filterBounds = function(geometry) {
+  var args = NamedArgs.extractFromFunction(Dataset.prototype.filterBounds, arguments);
+  geometry = args.geometry;
   this.collection_ = this.collection_.filterBounds(geometry);
   return this;
 };
@@ -105,11 +110,14 @@ Dataset.prototype.getDefaultVisParams = function() {
  */
 Dataset.prototype.createTemporalComposites = function(
     startDate, count, interval, intervalUnits, reducer) {
-  var args = NamedArgs.extractFromFunction(
-      Dataset.prototype.createTemporalComposites, arguments);
+  var args = NamedArgs.extractFromFunction(Dataset.prototype.createTemporalComposites, arguments);
+  startDate = args.startDate;
+  count = args.count;
+  interval = args.interval;
+  intervalUnits = args.intervalUnits;
+  reducer = args.reducer;
   this.collection_ = Composites.createTemporalComposites(
-      this.collection_, args.startDate, args.count, args.interval,
-      args.intervalUnits, args.reducer);
+      this.collection_, startDate, count, interval, intervalUnits, reducer);
   return this;
 };
 
@@ -124,6 +132,8 @@ Dataset.prototype.createTemporalComposites = function(
  * @return {!ee.ImageCollection}
  */
 Dataset.prototype.createMedioidComposite = function(bands) {
+  var args = NamedArgs.extractFromFunction(Dataset.prototype.createMedioidComposite, arguments);
+  bands = args.bands;
   this.collection_ = ee.ImageCollection(
       [Composites.createMedioidComposite(this.collection_, bands)]);
   return this;

--- a/toolkits/landcover/impl/landsat8.js
+++ b/toolkits/landcover/impl/landsat8.js
@@ -85,6 +85,7 @@ Landsat8.prototype.maskCloudsAndShadows = function() {
  * @return {!ee.Image}
  */
 Landsat8.maskCloudsAndShadows = function(image) {
+  // Named args not supported for single object arg function signatures.
   var qa = image.select(QA_BAND);
   // Both flags should be set to zero, indicating clear conditions.
   var mask = qa.bitwiseAnd(CLOUD_SHADOW_BIT_MASK)

--- a/toolkits/landcover/impl/named-args.js
+++ b/toolkits/landcover/impl/named-args.js
@@ -43,7 +43,6 @@ NamedArgs.extractFromFunction = function(fn, originalArgs) {
     throw new Error('Unsupported function declaration:\n' + fn.toString());
   }
   var argNames = regexMatch[1].split(',');
-
   var dict = {};
   for (var i in argNames) {
     var argName = argNames[i].trim();

--- a/toolkits/landcover/impl/named-args.js
+++ b/toolkits/landcover/impl/named-args.js
@@ -21,8 +21,6 @@
  */
 var FUNCTION_REGEX = /^function\s*(?:.*?)\(\s*(.*)\s*\)/;
 
-var NamedArgs = {};
-
 /**
  * Returns a dictionary of arguments keyed by function argument name. Toolkit
  * functions to simulate the "named args" feature of other popular languages
@@ -34,7 +32,7 @@ var NamedArgs = {};
  * @return {*} Dictionary with values keyed by argument names defined in the
  *   specified function declaration.
  */
-NamedArgs.extractFromFunction = function(fn, originalArgs) {
+function extractFromFunction(fn, originalArgs) {
   if (originalArgs.length == 1 && typeof originalArgs[0] === 'object') {
     return originalArgs[0];
   }
@@ -51,4 +49,6 @@ NamedArgs.extractFromFunction = function(fn, originalArgs) {
   return dict;
 };
 
-exports.NamedArgs = NamedArgs;
+exports.NamedArgs = {
+  extractFromFunction: extractFromFunction
+};

--- a/toolkits/landcover/impl/named-args.js
+++ b/toolkits/landcover/impl/named-args.js
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Regular expression used to extract argument names from string represention
+ * of a function.
+ */
+var FUNCTION_REGEX = /^function\s*(?:.*?)\(\s*(.*)\s*\)/;
+
+var NamedArgs = {};
+
+/**
+ * Returns a dictionary of arguments keyed by function argument name. Toolkit
+ * functions to simulate the "named args" feature of other popular languages
+ * using plain old JavaScript.
+ *
+ * @param {!Function} fn The function declaration.
+ * @param {!Array<*>} originalArgs The original arguments passed to the function
+ *   call.
+ */
+NamedArgs.extractFromFunction = function(fn, originalArgs) {
+  if (originalArgs.length == 1 && typeof originalArgs[0] === 'object') {
+    return originalArgs[0];
+  }
+  var regexMatch = fn.toString().match(FUNCTION_REGEX);
+  if (!regexMatch || regexMatch.length < 2) {
+    throw new Error('Unsupported function declaration:\n' + fn.toString());
+  }
+  var argNames= regexMatch[1].split(',');
+  var dict = {};
+  for (var i in argNames) {
+    var argName = argNames[i].trim();
+    dict[argName] = i < originalArgs.length ? originalArgs[i] : undefined;
+  }
+  return dict;
+};
+
+exports.NamedArgs = NamedArgs;

--- a/toolkits/landcover/impl/named-args.js
+++ b/toolkits/landcover/impl/named-args.js
@@ -33,14 +33,19 @@ var FUNCTION_REGEX = /^function\s*(?:.*?)\(\s*(.*)\s*\)/;
  *   specified function declaration.
  */
 function extractFromFunction(fn, originalArgs) {
+  // Functions with a single dictionary argument are assumed to have been
+  // invoked using named args. This precludes us using named args for functions
+  // that take a single dictionary as arguments. 
   if (originalArgs.length == 1 && typeof originalArgs[0] === 'object') {
     return originalArgs[0];
   }
+  // Extract arg names using heuristic regex.
   var regexMatch = fn.toString().match(FUNCTION_REGEX);
   if (!regexMatch || regexMatch.length < 2) {
     throw new Error('Unsupported function declaration:\n' + fn.toString());
   }
   var argNames = regexMatch[1].split(',');
+  // Build dictionary keyed by argument name.
   var dict = {};
   for (var i in argNames) {
     var argName = argNames[i].trim();

--- a/toolkits/landcover/impl/named-args.js
+++ b/toolkits/landcover/impl/named-args.js
@@ -17,10 +17,22 @@
 
 /**
  * Regular expression used to extract argument names from string represention
- * of a function.
+ * of a function. This does the following:
+ * 
+ *  1. Match only when declaration starts with "function".
+ *  2. Ignores optional space and function name up to first "(".
+ *  3. Captures the contents all the way up to the next ")".
+ * 
+ * This expression assume newlines have already been stripped.
  */
-var FUNCTION_REGEX = /^function\s*(?:.*?)\(\s*(.*)\s*\)/;
+var FUNCTION_REGEX = /^function\s*.*?\((.*?)\)/;
 
+/**
+ * Regular expression for matching newlines. This includes both standard LFs
+ * and Windows CR+LF patterns. We use this to remove newlines, working around
+ * the fact that single-line mode isn't supported by JavaScript RegExp.
+ */
+var NEWLINE_REGEX = /\r?\n/g;
 /**
  * Returns a dictionary of arguments keyed by function argument name. Toolkit
  * functions to simulate the "named args" feature of other popular languages
@@ -33,6 +45,7 @@ var FUNCTION_REGEX = /^function\s*(?:.*?)\(\s*(.*)\s*\)/;
  *   specified function declaration.
  */
 function extractFromFunction(fn, originalArgs) {
+  var decl = fn.toString().replace(NEWLINE_REGEX, ' ');
   // Functions with a single dictionary argument are assumed to have been
   // invoked using named args. This precludes us using named args for functions
   // that take a single dictionary as arguments. 
@@ -40,7 +53,7 @@ function extractFromFunction(fn, originalArgs) {
     return originalArgs[0];
   }
   // Extract arg names using heuristic regex.
-  var regexMatch = fn.toString().match(FUNCTION_REGEX);
+  var regexMatch = decl.match(FUNCTION_REGEX);
   if (!regexMatch || regexMatch.length < 2) {
     throw new Error('Unsupported function declaration:\n' + fn.toString());
   }

--- a/toolkits/landcover/impl/named-args.js
+++ b/toolkits/landcover/impl/named-args.js
@@ -40,7 +40,8 @@ NamedArgs.extractFromFunction = function(fn, originalArgs) {
   if (!regexMatch || regexMatch.length < 2) {
     throw new Error('Unsupported function declaration:\n' + fn.toString());
   }
-  var argNames= regexMatch[1].split(',');
+  var argNames = regexMatch[1].split(',');
+
   var dict = {};
   for (var i in argNames) {
     var argName = argNames[i].trim();

--- a/toolkits/landcover/impl/named-args.js
+++ b/toolkits/landcover/impl/named-args.js
@@ -31,6 +31,8 @@ var NamedArgs = {};
  * @param {!Function} fn The function declaration.
  * @param {!Array<*>} originalArgs The original arguments passed to the function
  *   call.
+ * @return {*} Dictionary with values keyed by argument names defined in the
+ *   specified function declaration.
  */
 NamedArgs.extractFromFunction = function(fn, originalArgs) {
   if (originalArgs.length == 1 && typeof originalArgs[0] === 'object') {

--- a/toolkits/landcover/impl/named-args.js
+++ b/toolkits/landcover/impl/named-args.js
@@ -59,16 +59,14 @@ var BLOCK_COMMENT_REGEX = /[/][*].*?[*][/]/g;
  *   specified function declaration.
  */
 function extractFromFunction(fn, originalArgs) {
-  var decl = fn.toString();
-  // Strip line comments:
-  decl = decl.replace(LINE_COMMENT_REGEX, '');
-  // Strip newlines:
-  decl = decl.replace(NEWLINE_REGEX, '');
-  // Strip block comments:
-  decl = decl.replace(BLOCK_COMMENT_REGEX, '');
+  // Strip comments and newlines:
+  var decl = fn.toString()
+                 .replace(LINE_COMMENT_REGEX, '')
+                 .replace(NEWLINE_REGEX, '')
+                 .replace(BLOCK_COMMENT_REGEX, '');
   // Functions with a single dictionary argument are assumed to have been
   // invoked using named args. This precludes us using named args for functions
-  // that take a single dictionary as arguments. 
+  // that take a single dictionary as arguments.
   if (originalArgs.length == 1 && typeof originalArgs[0] === 'object') {
     return originalArgs[0];
   }

--- a/toolkits/landcover/impl/region.js
+++ b/toolkits/landcover/impl/region.js
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+var NamedArgs = require('users/google/toolkits:landcover/impl/named-args').NamedArgs;
+
 /**
  * Returns a feature collection containing the feature in the Large Scale
  * International Boundaries (LSIB) that matches the specified name or code. If
@@ -25,6 +27,8 @@
  * @return {!ee.FeatureCollection}
  */
 function lsib(nameOrCode) {
+  var args = NamedArgs.extractFromFunction(lsib, arguments);
+  nameOrCode = args.nameOrCode;
   return ee.FeatureCollection('USDOS/LSIB_SIMPLE/2017')
       .filter(ee.Filter.or(
           ee.Filter.eq('country_na', nameOrCode),

--- a/toolkits/landcover/test/int/composites.int.test.js
+++ b/toolkits/landcover/test/int/composites.int.test.js
@@ -33,13 +33,13 @@ withEarthEngine('Composites', function() {
       TestImage.create({value: 550}, '2016-04-15')
     ]);
 
-    // TODO(#38): Replace args with dictionary once names args is implemented.
-    var result = lct.Composites.createTemporalComposites(
-        testCollection,
-        /* startDate= */ '2016-01-01',
-        /* count= */ 3,
-        /* interval= */ 1,
-        /* intervalUnits= */ 'month', ee.Reducer.mean());
+    var result = lct.Composites.createTemporalComposites({
+        collection: testCollection,
+        startDate: '2016-01-01',
+        count: 3,
+        interval: 1,
+        intervalUnits: 'month',
+        compositor: ee.Reducer.mean()});
 
     TestImage.reduceConstants(result.select('value'))
         .evaluate(function(actual, error) {
@@ -50,7 +50,7 @@ withEarthEngine('Composites', function() {
         });
   });
 
-  it('createMedioidComposite()', function(done) {
+  it('createMedioidComposite() w/single band', function(done) {
     // Median idx = 3, so we expect the pixel(s) with idx closest to that
     // value to be returned.
     var testCollection = ee.ImageCollection([
@@ -64,8 +64,8 @@ withEarthEngine('Composites', function() {
       TestImage.create({idx: 4, value: 400})
     ]);
 
-    var composite =
-        lct.Composites.createMedioidComposite(testCollection, 'idx');
+    var composite = lct.Composites.createMedioidComposite(
+        {collection: testCollection, bands: 'idx'});
 
     TestImage.reduceConstant(composite).evaluate(function(actual, error) {
       expect(error).toBeUndefined();
@@ -74,7 +74,7 @@ withEarthEngine('Composites', function() {
     });
   });
 
-  it('createMultibandMedioidComposite()', function(done) {
+  it('createMedioidComposite() w/multiple bands', function(done) {
     // Median idx = 3, so we expect the pixel(s) with idx closest to that
     // value to be returned.
     var testCollection = ee.ImageCollection([
@@ -86,8 +86,8 @@ withEarthEngine('Composites', function() {
       TestImage.create({a: 3, b: 3, c: 30, value: 300}),
     ]);
 
-    var composite =
-        lct.Composites.createMedioidComposite(testCollection, ['a', 'b', 'c']);
+    var composite = lct.Composites.createMedioidComposite(
+        {collection: testCollection, bands: ['a', 'b', 'c']});
 
     TestImage.reduceConstant(composite).evaluate(function(actual, error) {
       expect(error).toBeUndefined();
@@ -118,13 +118,13 @@ withEarthEngine('Composites', function() {
     // With 1 composite, this should be equivalent to the
     // medioidComposite test.
     var compositor = lct.Composites.createMedioidFunction('idx');
-    // TODO(#38): Replace args with dictionary once names args is implemented.
-    var result = lct.Composites.createTemporalComposites(
-        testCollection,
-        /* startDate= */ '2016-01-01',
-        /* count= */ 1,
-        /* interval= */ 31,
-        /* intervalUnits= */ 'day', compositor);
+    var result = lct.Composites.createTemporalComposites({
+        collection: testCollection,
+        startDate: '2016-01-01',
+        count: 1,
+        interval: 31,
+        intervalUnits: 'day',
+        compositor: compositor});
 
     TestImage.reduceConstants(result).evaluate(function(actual, error) {
       expect(error).toBeUndefined();

--- a/toolkits/landcover/test/int/landsat8.int.test.js
+++ b/toolkits/landcover/test/int/landsat8.int.test.js
@@ -38,7 +38,7 @@ function TestLandsat8(testCollection) {
 }
 
 withEarthEngine('Landsat8', function() {
-  it('fmaskCloudsAndShadows() masks cloudy pixels', function(done) {
+  it('maskCloudsAndShadows() masks cloudy pixels', function(done) {
     var clearPixel = TestImage.create({pixel_qa: 0, B4: CLEAR_PIXEL_VALUE});
     var cloudyPixel = TestImage.create(
         {pixel_qa: lct.Landsat8.CLOUD_BIT_MASK, B4: CLOUDY_PIXEL_VALUE});
@@ -57,7 +57,7 @@ withEarthEngine('Landsat8', function() {
     });
   });
 
-  it('fmaskCloudsAndShadows() masks shadowy pixels', function(done) {
+  it('maskCloudsAndShadows() masks shadowy pixels', function(done) {
     var clearPixel = TestImage.create({pixel_qa: 0, B4: CLEAR_PIXEL_VALUE});
     var shadowyPixel = TestImage.create({
       pixel_qa: lct.Landsat8.CLOUD_SHADOW_BIT_MASK,

--- a/toolkits/landcover/test/int/landsat8.int.test.js
+++ b/toolkits/landcover/test/int/landsat8.int.test.js
@@ -45,7 +45,7 @@ withEarthEngine('Landsat8', function() {
     var testCollection = ee.ImageCollection([clearPixel, cloudyPixel]);
     var l8 = TestLandsat8(testCollection);
 
-    var maskedL8 = l8.fmaskCloudsAndShadows();
+    var maskedL8 = l8.maskCloudsAndShadows();
 
     // Verify cloud-free pixel was returned.
     var image = maskedL8.getImageCollection().mosaic();
@@ -66,7 +66,7 @@ withEarthEngine('Landsat8', function() {
     var testCollection = ee.ImageCollection([clearPixel, shadowyPixel]);
     var l8 = TestLandsat8(testCollection);
 
-    var maskedL8 = l8.fmaskCloudsAndShadows();
+    var maskedL8 = l8.maskCloudsAndShadows();
 
     // Verify cloud shadow-free pixel was returned.
     var image = maskedL8.getImageCollection().mosaic();

--- a/toolkits/landcover/test/unit/named-args.unit.test.js
+++ b/toolkits/landcover/test/unit/named-args.unit.test.js
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var NamedArgs = require('../../impl/named-args').NamedArgs;
+
+// Test function acts as a thin wrapper, returning exactly what is returned
+// by extractFromFunction for testing.
+var testFunction = function(foo, bar, baz) {
+  return NamedArgs.extractFromFunction(testFunction, arguments);
+};
+
+withEarthEngineStub('NamedArgs', function() {
+  it('extractFromFunction() builds dictionary', function() {
+    var actual = testFunction(3, 141, 59);
+    var expected = {foo: 3, bar: 141, baz: 59};
+    expect(actual).toEqual(expected);
+  });
+
+  it('extractFromFunction() returns dictionary if specified', function() {
+    var actual = testFunction({foo: 3, bar: 141, baz: 59});
+    var expected = {foo: 3, bar: 141, baz: 59};
+    expect(actual).toEqual(expected);
+  });
+
+  it('extractFromFunction() throws error on unsupported fn declaration',
+     function() {
+       // Create function with stubbed toString() method to simulate invalid
+       // signature. This could happen if function signatures are encountered
+       // that were not accounted for by the current implementation.
+       var badFunction = function() {};
+       badFunction.toString = function() {
+         return 'bad signature';
+       };
+       expect(function() {
+         NamedArgs.extractFromFunction(badFunction, []);
+       }).toThrow();
+     });
+});

--- a/toolkits/landcover/test/unit/named-args.unit.test.js
+++ b/toolkits/landcover/test/unit/named-args.unit.test.js
@@ -18,6 +18,13 @@
 var NamedArgs = require('../../impl/named-args').NamedArgs;
 
 withEarthEngineStub('NamedArgs', function() {
+  it('extractFromFunction() with no args', function() {
+    var testFunction = function() {};
+    var actual = NamedArgs.extractFromFunction(testFunction, []);
+    var expected = {};
+    expect(actual).toEqual(expected);
+  });
+
   it('extractFromFunction() builds dictionary', function() {
     var testFunction = function(foo, bar, baz) {};
     var actual = NamedArgs.extractFromFunction(testFunction, [3, 141, 59]);

--- a/toolkits/landcover/test/unit/named-args.unit.test.js
+++ b/toolkits/landcover/test/unit/named-args.unit.test.js
@@ -40,6 +40,29 @@ withEarthEngineStub('NamedArgs', function() {
     expect(actual).toEqual(expected);
   });
 
+  it('extractFromFunction() with null args', function() {
+    var testFunction = function(foo, bar) {};
+    var actual = NamedArgs.extractFromFunction(testFunction, [null, null]);
+    var expected = {foo: null, bar: null};
+    expect(actual).toEqual(expected);
+  });
+
+  it('extractFromFunction() with undefined args', function() {
+    var testFunction = function(foo, bar) {};
+    var actual =
+        NamedArgs.extractFromFunction(testFunction, [undefined, undefined]);
+    var expected = {foo: undefined, bar: undefined};
+    expect(actual).toEqual(expected);
+  });
+
+  it('extractFromFunction() with too few args', function() {
+    var testFunction = function(foo, bar) {};
+    var actual =
+        NamedArgs.extractFromFunction(testFunction, [3]);
+    var expected = {foo: 3, bar: undefined};
+    expect(actual).toEqual(expected);
+  });
+
   it('extractFromFunction() fails on unsupported fn declaration', function() {
     // Create object with stubbed toString() method to simulate function
     // with invalid signature. This could happen if function signatures are

--- a/toolkits/landcover/test/unit/named-args.unit.test.js
+++ b/toolkits/landcover/test/unit/named-args.unit.test.js
@@ -17,65 +17,66 @@
 
 var NamedArgs = require('../../impl/named-args').NamedArgs;
 
-// Test function acts as a thin wrapper, returning exactly what is returned
-// by extractFromFunction for testing.
-var testFunction = function(foo, bar, baz) {
-  return NamedArgs.extractFromFunction(testFunction, arguments);
-};
-
 withEarthEngineStub('NamedArgs', function() {
   it('extractFromFunction() builds dictionary', function() {
-    var actual = testFunction(3, 141, 59);
+    var testFunction = function(foo, bar, baz) {};
+    var actual = NamedArgs.extractFromFunction(testFunction, [3, 141, 59]);
     var expected = {foo: 3, bar: 141, baz: 59};
     expect(actual).toEqual(expected);
   });
 
   it('extractFromFunction() returns dictionary if specified', function() {
-    var actual = testFunction({foo: 3, bar: 141, baz: 59});
+    var testFunction = function(foo, bar, baz) {};
+    var actual = NamedArgs.extractFromFunction(
+        testFunction, [{foo: 3, bar: 141, baz: 59}]);
     var expected = {foo: 3, bar: 141, baz: 59};
     expect(actual).toEqual(expected);
   });
 
   it('extractFromFunction() fails on unsupported fn declaration', function() {
-    // Create function with stubbed toString() method to simulate invalid
-    // signature. This could happen if function signatures are encountered
-    // that were not accounted for by the current implementation.
-    var badFunction = function() {};
-    badFunction.toString = function() {
-      return 'bad signature';
+    // Create object with stubbed toString() method to simulate function
+    // with invalid signature. This could happen if function signatures are
+    // encountered that were not accounted for by the current implementation.
+    var badFunction = {
+      toString: function() {
+        return 'bad signature';
+      }
     };
     expect(function() {
       NamedArgs.extractFromFunction(badFunction, []);
     }).toThrow();
   });
 
-  it('extractFromFunction() strips line comments', function() {
-    var testFunction = function(
-        arg1,  // line comment
-        arg2   // line comment 2
-    ) {};
-    var actual = NamedArgs.extractFromFunction(testFunction, ['val1', 'val2']);
-    var expected = {arg1: 'val1', arg2: 'val2'};
-    expect(actual).toEqual(expected);
-  });
+    it('extractFromFunction() strips line comments', function() {
+      var testFunction = function(
+          arg1,  // line comment
+          arg2   // line comment 2
+      ) {};
+      var actual =
+          NamedArgs.extractFromFunction(testFunction, ['val1', 'val2']);
+      var expected = {arg1: 'val1', arg2: 'val2'};
+      expect(actual).toEqual(expected);
+    });
 
 
-  it('extractFromFunction() strips block comments', function() {
-    var testFunction = function(
-        /* block comment 1 */ arg1,
-        /* block comment 2 */ arg2) {};
-    var actual = NamedArgs.extractFromFunction(testFunction, ['val1', 'val2']);
-    var expected = {arg1: 'val1', arg2: 'val2'};
-    expect(actual).toEqual(expected);
-  });
+    it('extractFromFunction() strips block comments', function() {
+      var testFunction = function(
+          /* block comment 1 */ arg1,
+          /* block comment 2 */ arg2) {};
+      var actual =
+          NamedArgs.extractFromFunction(testFunction, ['val1', 'val2']);
+      var expected = {arg1: 'val1', arg2: 'val2'};
+      expect(actual).toEqual(expected);
+    });
 
-  it('extractFromFunction() ignore dangling commas', function() {
-    var testFunction = function(
-        arg1,
-        arg2,
-    ) {};
-    var actual = NamedArgs.extractFromFunction(testFunction, ['val1', 'val2']);
-    var expected = {arg1: 'val1', arg2: 'val2'};
-    expect(actual).toEqual(expected);
+    it('extractFromFunction() ignore dangling commas', function() {
+      var testFunction = function(
+          arg1,
+          arg2,
+      ) {};
+      var actual =
+          NamedArgs.extractFromFunction(testFunction, ['val1', 'val2']);
+      var expected = {arg1: 'val1', arg2: 'val2'};
+      expect(actual).toEqual(expected);
+    });
   });
-});

--- a/toolkits/landcover/test/unit/named-args.unit.test.js
+++ b/toolkits/landcover/test/unit/named-args.unit.test.js
@@ -36,17 +36,46 @@ withEarthEngineStub('NamedArgs', function() {
     expect(actual).toEqual(expected);
   });
 
-  it('extractFromFunction() throws error on unsupported fn declaration',
-     function() {
-       // Create function with stubbed toString() method to simulate invalid
-       // signature. This could happen if function signatures are encountered
-       // that were not accounted for by the current implementation.
-       var badFunction = function() {};
-       badFunction.toString = function() {
-         return 'bad signature';
-       };
-       expect(function() {
-         NamedArgs.extractFromFunction(badFunction, []);
-       }).toThrow();
-     });
+  it('extractFromFunction() fails on unsupported fn declaration', function() {
+    // Create function with stubbed toString() method to simulate invalid
+    // signature. This could happen if function signatures are encountered
+    // that were not accounted for by the current implementation.
+    var badFunction = function() {};
+    badFunction.toString = function() {
+      return 'bad signature';
+    };
+    expect(function() {
+      NamedArgs.extractFromFunction(badFunction, []);
+    }).toThrow();
+  });
+
+  it('extractFromFunction() strips line comments', function() {
+    var testFunction = function(
+        arg1,  // line comment
+        arg2   // line comment 2
+    ) {};
+    var actual = NamedArgs.extractFromFunction(testFunction, ['val1', 'val2']);
+    var expected = {arg1: 'val1', arg2: 'val2'};
+    expect(actual).toEqual(expected);
+  });
+
+
+  it('extractFromFunction() strips block comments', function() {
+    var testFunction = function(
+        /* block comment 1 */ arg1,
+        /* block comment 2 */ arg2) {};
+    var actual = NamedArgs.extractFromFunction(testFunction, ['val1', 'val2']);
+    var expected = {arg1: 'val1', arg2: 'val2'};
+    expect(actual).toEqual(expected);
+  });
+
+  it('extractFromFunction() ignore dangling commas', function() {
+    var testFunction = function(
+        arg1,
+        arg2,
+    ) {};
+    var actual = NamedArgs.extractFromFunction(testFunction, ['val1', 'val2']);
+    var expected = {arg1: 'val1', arg2: 'val2'};
+    expect(actual).toEqual(expected);
+  });
 });


### PR DESCRIPTION
Implements JavaScript hack to approximate named args functionality of other languages (`functionName({arg1: value1, args2: value2})`)  and applies to all relevant functions.