### PR TITLE
[Landcover Toolkit] Only skip named args for single arg objects if untyped dictionaries

### DIFF
--- a/toolkits/landcover/impl/named-args.js
+++ b/toolkits/landcover/impl/named-args.js
@@ -67,7 +67,8 @@ function extractFromFunction(fn, originalArgs) {
   // Functions with a single dictionary argument are assumed to have been
   // invoked using named args. This precludes us using named args for functions
   // that take a single dictionary as arguments.
-  if (originalArgs.length == 1 && typeof originalArgs[0] === 'object') {
+  if (originalArgs.length == 1 && typeof originalArgs[0] === 'object' &&
+      !(originalArgs[0] instanceof ee.ComputedObject)) {
     return originalArgs[0];
   }
   // Extract arg names using heuristic regex.

--- a/toolkits/landcover/impl/named-args.js
+++ b/toolkits/landcover/impl/named-args.js
@@ -48,6 +48,17 @@ var NEWLINE_REGEX = /\r?\n/g;
 var BLOCK_COMMENT_REGEX = /[/][*].*?[*][/]/g;
 
 /**
+ * Returns true iff the provided value is a JavaScript dictionary, as opposed
+ * to a scalar or a typed class instance.
+ *
+ * @param {*} value
+ * @return {boolean}
+ */
+function isDictionary_(value) {
+  return value.constructor.name === 'Object';
+}
+
+/**
  * Returns a dictionary of arguments keyed by function argument name. Toolkit
  * functions to simulate the "named args" feature of other popular languages
  * using plain old JavaScript.
@@ -64,11 +75,10 @@ function extractFromFunction(fn, originalArgs) {
                  .replace(LINE_COMMENT_REGEX, '')
                  .replace(NEWLINE_REGEX, '')
                  .replace(BLOCK_COMMENT_REGEX, '');
-  // Functions with a single dictionary argument are assumed to have been
-  // invoked using named args. This precludes us using named args for functions
-  // that take a single dictionary as arguments.
-  if (originalArgs.length == 1 && typeof originalArgs[0] === 'object' &&
-      !(originalArgs[0] instanceof ee.ComputedObject)) {
+  // Functions with a single JavaScript dictionary argument are assumed to have
+  // been invoked using named args. This precludes us using named args for
+  // functions that take a single dictionary as arguments.
+  if (originalArgs.length == 1 && isDictionary_(originalArgs[0])) {
     return originalArgs[0];
   }
   // Extract arg names using heuristic regex.

--- a/toolkits/landcover/test/unit/named-args.unit.test.js
+++ b/toolkits/landcover/test/unit/named-args.unit.test.js
@@ -40,6 +40,14 @@ withEarthEngineStub('NamedArgs', function() {
     expect(actual).toEqual(expected);
   });
 
+  fit('extractFromFunction() builds dict for EE objects', function() {
+    var testFunction = function(foo) {};
+    var testImage = ee.Image([0]);
+    var actual = NamedArgs.extractFromFunction(testFunction, [testImage]);
+    var expected = {foo: testImage};
+    expect(actual).toEqual(expected);
+  });
+
   it('extractFromFunction() with null args', function() {
     var testFunction = function(foo, bar) {};
     var actual = NamedArgs.extractFromFunction(testFunction, [null, null]);

--- a/toolkits/landcover/test/unit/named-args.unit.test.js
+++ b/toolkits/landcover/test/unit/named-args.unit.test.js
@@ -40,7 +40,7 @@ withEarthEngineStub('NamedArgs', function() {
     expect(actual).toEqual(expected);
   });
 
-  fit('extractFromFunction() builds dict for EE objects', function() {
+  it('extractFromFunction() builds dict for EE objects', function() {
     var testFunction = function(foo) {};
     var testImage = ee.Image([0]);
     var actual = NamedArgs.extractFromFunction(testFunction, [testImage]);

--- a/toolkits/landcover/test/unit/named-args.unit.test.js
+++ b/toolkits/landcover/test/unit/named-args.unit.test.js
@@ -48,6 +48,22 @@ withEarthEngineStub('NamedArgs', function() {
     expect(actual).toEqual(expected);
   });
 
+  it('extractFromFunction() builds dict for arrays', function() {
+    var testFunction = function(foo) {};
+    var testArray = [1, 2, 3];
+    var actual = NamedArgs.extractFromFunction(testFunction, [testArray]);
+    var expected = {foo: testArray};
+    expect(actual).toEqual(expected);
+  });
+
+  it('extractFromFunction() builds dict for Dates', function() {
+    var testFunction = function(foo) {};
+    var testDate = new Date();
+    var actual = NamedArgs.extractFromFunction(testFunction, [testDate]);
+    var expected = {foo: testDate};
+    expect(actual).toEqual(expected);
+  });
+
   it('extractFromFunction() with null args', function() {
     var testFunction = function(foo, bar) {};
     var actual = NamedArgs.extractFromFunction(testFunction, [null, null]);


### PR DESCRIPTION
Fixes #38.

 