### PR TITLE
[Landcover Toolkit] Fix Tasseled Cap unit tests

### DIFF
--- a/toolkits/landcover/test/unit/datasets.unit.test.js
+++ b/toolkits/landcover/test/unit/datasets.unit.test.js
@@ -23,4 +23,8 @@ withEarthEngineStub('Datasets', function() {
       new Dataset().addTasseledCap();
     }).toThrow();
   });
+
+  it('getTasseledCapCoefficients_() returns null', function() {
+    expect(new Dataset().getTasseledCapCoefficients_()).toEqual(null);
+  });
 });

--- a/toolkits/landcover/test/unit/datasets.unit.test.js
+++ b/toolkits/landcover/test/unit/datasets.unit.test.js
@@ -23,8 +23,4 @@ withEarthEngineStub('Datasets', function() {
       new Dataset().addTasseledCap();
     }).toThrow();
   });
-
-  it('check getTasseledCapCoefficients is unsupported on the baseclass.', function() {
-    expect(new Dataset().getTasseledCapCoefficients()).toEqual(null);
-  });
 });

--- a/toolkits/landcover/test/unit/landsat8.unit.test.js
+++ b/toolkits/landcover/test/unit/landsat8.unit.test.js
@@ -31,8 +31,8 @@ withEarthEngineStub('Landsat8', function() {
     expect(newImage).toEqual(expected);
   });
 
-  it('getTasseledCapCoefficients() returns coefficients.', function() {
+  it('getTasseledCapCoefficients_() returns coefficients', function() {
     // There are 6 bands in the TC transformation.  There should be 6 coefficients.
-    expect(new Landsat8('SR').getTasseledCapCoefficients().length).toEqual(6);
+    expect(new Landsat8('SR').getTasseledCapCoefficients_().length).toEqual(6);
   });
 });


### PR DESCRIPTION
Side note: we'd normally prefer to test behavior of public methods only, with private methods being considered implementation instead of behavior (https://testing.googleblog.com/2013/08/testing-on-toilet-test-behavior-not.html). That said, since we're not able to only inspect parts of the request graph, and since we agreed we wouldn't check equality on the whole graph (which would be change detection tests), this will have to do for now.

Fixes #92, blocking #87. 