### PR TITLE
Edit MODIS NDVI Animation

### DIFF
--- a/tutorials/modis-ndvi-time-series-animation/index.md
+++ b/tutorials/modis-ndvi-time-series-animation/index.md
@@ -21,25 +21,31 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-[Open In Code Editor](https://code.earthengine.google.com/0ee1513ac09808307463585f73dda77c)
+[Open In Code Editor](https://code.earthengine.google.com/71b14acfca89099a010adceef8f7f9bb)
 
-Time series animations of Earth observation imagery are captivating and engaging.
-In this tutorial, you'll learn how to generate an animated GIF representing 20-year median
-NDVI for serial 16-day MODIS composites spanning January 1st through December 31st. The
-following image is an example of the resulting animation. 
+Time series animations of Earth observation imagery are captivating and
+engaging. In this tutorial, you'll learn how to generate an animated GIF
+representing 20-year median NDVI for serial 16-day MODIS composites spanning
+January 1st through December 31st. The following image is an example of the
+resulting animation. 
 
 ![MODIS NDVI GIF](https://storage.googleapis.com/earthengine-community/tutorials/modis-ndvi-time-series-animation/modis-ndvi-time-series-animation.gif)
 
 ## Context
 
-[MODIS](https://modis.gsfc.nasa.gov/) is a moderate resolution satellite imaging system and NDVI is a 
-common reflectance-based vegetation index. The [Earth Engine Data Catalog](https://developers.google.com/earth-engine/datasets/)
-provides NDVI as a precalculated [dataset](https://developers.google.com/earth-engine/datasets/catalog/MODIS_006_MOD13A2)
-for convenience. In the above animation, NDVI is mapped to a color gradient from tan to dark green representing 
-low to high photosynthetic capacity (low to high vegetation cover/density/productivity). The
-tide-like latitudinal shift in vegetation is associated with the sun’s declination moving between 23.5&deg;
-north and 23.5&deg; south, relative to the equator, throughout the year. See [Nicholson, 2019](https://journals.ametsoc.org/doi/full/10.1175/BAMS-D-16-0287.1) for more information on this phenomenon. Similar
-seasonal patterns of vegetation productivity are found around the world at both small and large scales.
+[MODIS](https://modis.gsfc.nasa.gov/) is a moderate resolution satellite imaging
+system and NDVI is a common reflectance-based vegetation index. The
+[Earth Engine Data Catalog](https://developers.google.com/earth-engine/datasets/)
+provides NDVI as a precalculated
+[dataset](https://developers.google.com/earth-engine/datasets/catalog/MODIS_006_MOD13A2)
+for convenience. In the above animation, NDVI is mapped to a color gradient from
+tan to dark green representing low to high photosynthetic capacity (low to high
+vegetation cover/density/productivity). The tide-like latitudinal shift in
+vegetation is associated with the sun’s declination moving between 23.5&deg;
+north and 23.5&deg; south, relative to the equator, throughout the year. See
+[Nicholson, 2019](https://journals.ametsoc.org/doi/full/10.1175/BAMS-D-16-0287.1)
+for more information on this phenomenon. Similar seasonal patterns of vegetation
+productivity are found around the world at both small and large scales.
 
 ## Instructions
 
@@ -49,7 +55,8 @@ The basic workflow is as follows:
 2. Define region of interest and animation frame geometries
 3. Group images from the same annual 16-day composite window using a join
 4. Reduce the composite groups by median to produce animation frames
-5. Define visualization parameters and convert data into RGB visualization images
+5. Define visualization parameters and convert data into RGB visualization
+images
 6. Generate a URL that will produce a GIF in the browser
 
 ### 1. Get MODIS NDVI collection
@@ -63,15 +70,20 @@ var col = ee.ImageCollection('MODIS/006/MOD13A2').select('NDVI');
 
 ### 2. Define clipping and region boundary geometries
 
-Clipping the data is an optional step that sets pixels outside an area of interest as null, which is helpful
-for drawing attention to a particular area within a region. Here, the [Large Scale International Boundary](https://developers.google.com/earth-engine/datasets/catalog/USDOS_LSIB_SIMPLE_2017)
-(LSIB) vector dataset is filtered to include only the collection of geometries composing Africa, whose union
-serves as the clipping geometry. When applied, all pixels outside of Africa will be null. Next, a polygon
-describing a rectangular extent of the desired animation is defined. In your own application, you may define
-these two geometries any number of ways. Note, however, that very large regional extents may exceed limitations
-of the function used to produce the animated GIF, in which case an error will be printed in the console.
-Please see the [Geometry Overview](https://developers.google.com/earth-engine/geometries) section of the
-Developers Guide for more information on defining geometries. Note that you can also [upload shapefiles](https://developers.google.com/earth-engine/importing#uploading-table-assets)
+Clipping the data is an optional step that sets pixels outside an area of
+interest as null, which is helpful for drawing attention to a particular area
+within a region. Here, the [Large Scale International Boundary](https://developers.google.com/earth-engine/datasets/catalog/USDOS_LSIB_SIMPLE_2017)
+(LSIB) vector dataset is filtered to include only the collection of geometries
+composing Africa, whose union serves as the clipping geometry. When applied, all
+pixels outside of Africa will be null. Next, a polygon describing a rectangular
+extent of the desired animation is defined. In your own application, you may
+define these two geometries any number of ways. Note, however, that very large
+regional extents may exceed limitations of the function used to produce the
+animated GIF, in which case an error will be printed in the console. Please see
+the [Geometry Overview](https://developers.google.com/earth-engine/geometries)
+section of the Developers Guide for more information on defining geometries.
+Note that you can also
+[upload shapefiles](https://developers.google.com/earth-engine/importing#uploading-table-assets)
 and import them as `ee.Geometry` objects.
 
 ```js
@@ -91,12 +103,14 @@ var region = ee.Geometry.Polygon(
 
 ### 3. Group images by composite date
 
-The data making up each frame of the animation is the 20-year median NDVI for the same 16-day composite each
-year from 2000 to 2019. Generating these median composites is the crux of this tutorial. The first step is
-grouping inter-annual image data representing the same 16-day composite window into lists. To do this, a
-calendar date needs to be added to the metadata of each image so there is a common property to group (join)
-by. Day-of-year (DOY) is a fine format and can be derived from the ubiquitous `system:time_start` property
-using the `getRelative` method.
+The data making up each frame of the animation is the 20-year median NDVI for
+the same 16-day composite each year from 2000 to 2019. Generating these median
+composites is the crux of this tutorial. The first step is grouping inter-annual
+image data representing the same 16-day composite window into lists. To do this,
+a calendar date needs to be added to the metadata of each image so there is a
+common property to group (join) by. Day-of-year (DOY) is a fine format and can
+be derived from the ubiquitous `system:time_start` property using the
+`getRelative` method.
 
 ```js
 col = col.map(function(img) {
@@ -105,10 +119,12 @@ col = col.map(function(img) {
 });
 ```
 
-A join operation will be implemented that groups images by the 'doy' property just added. The join operation 
-expects two collections, in this case: a distinct DOY collection and the complete collection modified to
-include the 'doy' property. The complete collection (`col`) exists, the distinct collection needs to be defined.
-Do so by filtering the complete collection to a single year of data e.g. 2013. 
+A join operation will be implemented that groups images by the 'doy' property
+just added. The join operation  expects two collections, in this case: a
+distinct DOY collection and the complete collection modified to include the
+'doy' property. The complete collection (`col`) exists, the distinct collection
+needs to be defined. Do so by filtering the complete collection to a single year
+of data e.g. 2013. 
 
 ```js
 var distinctDOY = col.filterDate('2013-01-01', '2014-01-01');
@@ -116,8 +132,10 @@ var distinctDOY = col.filterDate('2013-01-01', '2014-01-01');
 
 Complete the join by:
 
-1. Creating a filter that will identify matching images between the distinct and complete collections by the `doy` property
-2. Defining a `saveAll` join that will produce a list of all matches per distinct 'doy' in a property called 'doy_matches'
+1. Creating a filter that will identify matching images between the distinct and
+complete collections by the `doy` property
+2. Defining a `saveAll` join that will produce a list of all matches per
+distinct 'doy' in a property called 'doy_matches'
 3. Applying the join
 
 ```js
@@ -133,17 +151,20 @@ var join = ee.Join.saveAll('doy_matches');
 var joinCol = ee.ImageCollection(join.apply(distinctDOY, col, filter));
 ```
 
-The result (`joinCol`) is a copy of the distinct DOY collection with a property added to each image (`same_doy`) that lists all of the
-images from the complete collection (`col`) that have the same DOY for a given distinct DOY image.
+The result (`joinCol`) is a copy of the distinct DOY collection with a property
+added to each image (`same_doy`) that lists all of the images from the complete
+collection (`col`) that have the same DOY for a given distinct DOY image.
 
 ### 4. Reduce composite groups
 
-From the list of images having the same DOY, a collection can be created and then reduced to the median
-of its constituents. Map this oppertation over each distinct DOY image in the new `joinCol` collection.
-The result is a new collection, with one image per distinct DOY composite that represents its 20-year
-median NDVI per pixel. It took some work to get to this point, but using a central tendency statistic
-based on a population of data produces an annual time series animation that is free of missing data and
-outliers (i.e. the animation is less noisy).   
+From the list of images having the same DOY, a collection can be created and
+then reduced to the median of its constituents. Map this oppertation over each
+distinct DOY image in the new `joinCol` collection. The result is a new
+collection, with one image per distinct DOY composite that represents its
+20-year median NDVI per pixel. It took some work to get to this point, but using
+a central tendency statistic based on a population of data produces an annual
+time series animation that is free of missing data and outliers
+(i.e. the animation is less noisy).
 
 ```js
 // Apply median reduction among matching DOY collections.
@@ -157,11 +178,13 @@ var comp = joinCol.map(function(img) {
 
 ### 5. Make visualization images
 
-Set visualization properties to control the appearance of the data in the animation frames.
-The `visualize` method can convert single-band images (like NDVI)
-into 3-band RGB pseudo-color images. Define visualization properties including a color palette and min
-and max values to stretch the palette between. Map the `visualize` method over each image using the defined
-visualization properties and clip the data to the mask defined in [Step 2](#2-define-clipping-and-region-boundary-geometries)
+Set visualization properties to control the appearance of the data in the
+animation frames. The `visualize` method can convert single-band images
+(like NDVI) into 3-band RGB pseudo-color images. Define visualization properties
+including a color palette and min and max values to stretch the palette between.
+Map the `visualize` method over each image using the defined visualization
+properties and clip the data to the mask defined in
+[Step 2](#2-define-clipping-and-region-boundary-geometries)
 to set background pixels to null (black).
 
 ```js
@@ -184,8 +207,9 @@ var rgbVis = comp.map(function(img) {
 
 ### 6. Create an animated GIF
 
-The final step is to define arguments for the `getVideoThumbURL` method which will create an animation from
-the collection of RGB visualization images generated in the previous step. Relevant parameters include:
+The final step is to define arguments for the `getVideoThumbURL` method which
+will create an animation from the collection of RGB visualization images
+generated in the previous step. Relevant parameters include:
 
 - `region`: set to the region defined in above [Step 2](#2-define-clipping-and-region-boundary-geometries)
 - `dimensions`: set to 600 which defines the larger dimension of the resulting GIF as 600px (the smaller dimension
@@ -206,6 +230,19 @@ var gifParams = {
 print(rgbVis.getVideoThumbURL(gifParams));
 ```
 
-A URL will be printed to the console after running this block of code. Upon visiting the URL, Earth Engine servers
-will complete the work needed to produce the GIF on-the-fly. Once the task is complete, the animation will appear in
-the browser. Use the right-click context menu to select options for downloading the GIF file to your computer.
+A URL will be printed to the console after running this block of code. Upon
+visiting the URL, Earth Engine servers will complete the work needed to produce
+the GIF on-the-fly. Once the task is complete, the animation will appear in the
+browser.
+
+Alternatively, you can render the animation directly in the console using the
+`ui.Thumbnail` function.
+
+```js
+// Render the GIF animation in the console.
+print(ui.Thumbnail(rgbVis, gifParams));
+```
+
+Once the animation appears, you can download the image by right-clicking on it
+to reveal its context menu. Select the appropriate option to download the
+file to your computer.

--- a/tutorials/modis-ndvi-time-series-animation/modis-ndvi-time-series-animation.js
+++ b/tutorials/modis-ndvi-time-series-animation/modis-ndvi-time-series-animation.js
@@ -20,7 +20,7 @@ var col = ee.ImageCollection('MODIS/006/MOD13A2').select('NDVI');
 
 // Define a mask to clip the NDVI data by.
 var mask = ee.FeatureCollection('USDOS/LSIB_SIMPLE/2017')
-  .filter(ee.Filter.eq('wld_rgn', 'Europe'));
+  .filter(ee.Filter.eq('wld_rgn', 'Africa'));
 
 // Define the regional bounds of animation frames.
 var region = ee.Geometry.Polygon(
@@ -86,3 +86,6 @@ var gifParams = {
 
 // Print the GIF URL to the console.
 print(rgbVis.getVideoThumbURL(gifParams));
+
+// Render the GIF animation in the console.
+print(ui.Thumbnail(rgbVis, gifParams));


### PR DESCRIPTION
- Format lines to length 80
- Fix extent (Africa instead of Europe)
- Render animation with `ui.Thumbnail` in console so it can be downloaded locally.