### PR TITLE
A small fix in date formatting

### DIFF
--- a/tutorials/extract-raster-values-for-points/index.md
+++ b/tutorials/extract-raster-values-for-points/index.md
@@ -125,7 +125,7 @@ function zonalStats(ic, fc, params) {
     imgProps: null,
     imgPropsRename: null,
     datetimeName: 'datetime',
-    datetimeFormat: 'YYYY-MM-dd HH:MM:ss'
+    datetimeFormat: 'YYYY-MM-dd HH:mm:ss'
   };
 
   // Replace initialized params with provided params.


### PR DESCRIPTION
Replaces "datetimeFormat: 'YYYY-MM-dd HH:MM:ss'" with "datetimeFormat: 'YYYY-MM-dd HH:mm:ss'"