### PR TITLE
Fixing typos in Earth_Engine_PyTorch_Vertex_AI.ipynb

### DIFF
--- a/guides/linked/Earth_Engine_PyTorch_Vertex_AI.ipynb
+++ b/guides/linked/Earth_Engine_PyTorch_Vertex_AI.ipynb
@@ -173,7 +173,7 @@
         "MODEL_NAME = 'vertex_pytorch_demo'\n",
         "MODEL_DIR = OUTPUT_BUCKET + '/' + MODEL_NAME\n",
         "CONTAINER_IMAGE = 'us-docker.pkg.dev/vertex-ai/prediction/pytorch-cpu.1-12:latest'\n",
-        "ENDPOINT_NAME = 'vertex_pytorch_demo_endpoint'"
+        "ENDPOINT_NAME = 'vertex-pytorch-demo-endpoint'"
       ],
       "execution_count": null,
       "outputs": []
@@ -708,7 +708,7 @@
         "    True)\n",
         "\n",
         "endpoint_path = (\n",
-        "    'projects/' + PROJECT + '/locations/' + REGION + '/endpoints/' + str(ENDPOINT_ID))\n",
+        "    'projects/' + PROJECT + '/locations/' + REGION + '/endpoints/' + str(ENDPOINT_NAME))\n",
         "\n",
         "# Connect to the hosted model.\n",
         "vertex_model = ee.Model.fromVertexAi(\n",


### PR DESCRIPTION
Fixing typos for endpoint.  The endpoint can only have hyphens.  The EE code had a typo in it. 

Tan through successfully. 