### PR TITLE
Additional fixes for tutorial dedicated to groundwater recharge calculation with EE

### DIFF
--- a/tutorials/groundwater-recharge-estimation/index.ipynb
+++ b/tutorials/groundwater-recharge-estimation/index.ipynb
@@ -1891,7 +1891,7 @@
       "source": [
         "### Acknowledgements\n",
         "\n",
-        "Thanks to Susanne Benz for precious advice."
+        "Thanks to Susanne Benz for precious advice. Thanks to Saeed Mhanna and Wilfried Datchoua for additional reviews and corrections."
       ]
     }
   ],

--- a/tutorials/groundwater-recharge-estimation/index.ipynb
+++ b/tutorials/groundwater-recharge-estimation/index.ipynb
@@ -1205,7 +1205,7 @@
         "***Case 2.1: the storage $ST_{m}$ is higher than the water stored at the field capacity.***\n",
         "\n",
         "If $ST_{m} \u003e ST_{FC}$ the recharge is calculated as:\n",
-        "$R_{m} = ST_{m} - ST_{FC} + P_{m} - PET_{m}$\n",
+        "$R_{m} = ST_{m} - ST_{FC}$\n",
         "\n",
         "In addition, the water stored at the end of the month $m$ becomes equal to $ST_{FC}$ and $APWL_{m}$ is set equal to zero.\n",
         "\n",

--- a/tutorials/groundwater-recharge-estimation/index.ipynb
+++ b/tutorials/groundwater-recharge-estimation/index.ipynb
@@ -1731,7 +1731,7 @@
         "id": "kBwuvxPpT0-N"
       },
       "source": [
-        "The result shows that the annual recharge in Lyon is almost twice as high as in the area of Montpellier. The result also shows a great variability of the annual recharge ranging from 98 mm/y to 258 mm/y in Lyon and from 16 mm/y to 147 mm/y in Montpellier."
+        "The result shows that the annual recharge in Lyon is almost twice as high as in the area of Montpellier. The result also shows a great variability of the annual recharge ranging from 99 mm/y to 275 mm/y in Lyon and from 17 mm/y to 158 mm/y in Montpellier."
       ]
     },
     {

--- a/tutorials/groundwater-recharge-estimation/index.ipynb
+++ b/tutorials/groundwater-recharge-estimation/index.ipynb
@@ -46,7 +46,7 @@
         "\n",
         "In the second part, [OpenLandMap datasets](https://developers.google.com/earth-engine/datasets/tags/opengeohub) related to soil properties will be explored. The wilting point and field capacity of the soil will be calculated by applying some mathematical expressions to multiple images.\n",
         "\n",
-        "In the third part, [evapotranspiration](https://developers.google.com/earth-engine/datasets/catalog/MODIS_006_MOD16A2) and [precipitation](https://developers.google.com/earth-engine/datasets/catalog/UCSB-CHG_CHIRPS_DAILY) datasets will be imported. A function will be defined to resample the time resolution of an `ee.ImageCollection` and to homogenize time index of both datasets. Both datasets will then be combined into one.\n",
+        "In the third part, [evapotranspiration](https://developers.google.com/earth-engine/datasets/catalog/MODIS_061_MOD16A2GF) and [precipitation](https://developers.google.com/earth-engine/datasets/catalog/UCSB-CHG_CHIRPS_DAILY) datasets will be imported. A function will be defined to resample the time resolution of an `ee.ImageCollection` and to homogenize time index of both datasets. Both datasets will then be combined into one.\n",
         "\n",
         "In the fourth and final part, the Thornthwaite-Mather(TM) procedure will be implemented by iterating over the meteorological `ee.ImageCollection`. Finally, a comparison between groundwater recharge in two places will be described and the resulting mean annual groundwater recharge will be displayed over France."
       ]
@@ -721,7 +721,7 @@
         "\n",
         "The meteorological data used in our implementation of the TM procedure relies on the following datasets:\n",
         "- [Climate Hazards Group InfraRed Precipitation](https://developers.google.com/earth-engine/datasets/catalog/UCSB-CHG_CHIRPS_DAILY) with Station data (CHIRPS) gives precipitations on a daily basis (resolution of 5 km),\n",
-        "- [MODIS Terra Net](https://developers.google.com/earth-engine/datasets/catalog/MODIS_006_MOD16A2) gives evapotranspiration on a 8-days basis (resolution of 500 m).\n",
+        "- [MODIS Terra Net](https://developers.google.com/earth-engine/datasets/catalog/MODIS_061_MOD16A2GF) gives evapotranspiration on a 8-days basis (resolution of 500 m).\n",
         "\n",
         "Both datasets are imported as follows, specifying the bands of interest using [`.select()`](https://developers.google.com/earth-engine/apidocs/ee-imagecollection-select) and the period of interest using [`.filterDate()`](https://developers.google.com/earth-engine/apidocs/ee-imagecollection-filterdate)."
       ]
@@ -743,7 +743,7 @@
         "\n",
         "# Import potential evaporation PET and its quality indicator ET_QC.\n",
         "pet = (\n",
-        "    ee.ImageCollection(\"MODIS/006/MOD16A2\")\n",
+        "    ee.ImageCollection(\"MODIS/061/MOD16A2GF\")\n",
         "    .select([\"PET\", \"ET_QC\"])\n",
         "    .filterDate(i_date, f_date)\n",
         ")"


### PR DESCRIPTION
- replace deprecated MODIS Collection by MOD16A2GF.061: Terra Net Evapotranspiration Gap-Filled 8-Day Global 500m 
- fix values in the text considering the use of the new MODIS collection,
- fix formulae dedicated to recharge calculation to fit the code and the reference paper,
- acknowledgments of Saeed and Wilfried for corrections.